### PR TITLE
Use terraform workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,17 @@ export AWS_REGION=<ie us-east-1>
 export GOOGLE_REGION=<ie us-east1>
 ```
 
-### Initlialize terraform
+### Initialize terraform
 
 ```shell
 cd infrastructure
 terraform init
+terraform workspace new webservice
+terraform workspace new iot
+```
+
+### Migrate from existing state
+```sh
+cd infrastructure
+terraform workspace new webservice -state terraform.tfstate
 ```

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -12,9 +12,6 @@ variable "project_prefix" {
   default = "faaster"
 }
 
-variable "experiment" {
-}
-
 resource "random_string" "build_id" {
   length  = 16
   special = false
@@ -34,8 +31,12 @@ resource "random_string" "project_id" {
 }
 
 locals {
-  project_name = "${var.project_prefix}-${random_string.project_id.result}"
-  expconfig    = jsondecode(file("../experiments/${var.experiment}/experiment.json"))
+  experiment = terraform.workspace
+}
+
+locals {
+  project_name = "${var.project_prefix}-${local.experiment}-${random_string.project_id.result}"
+  expconfig    = jsondecode(file("../experiments/${local.experiment}/experiment.json"))
 }
 
 locals {
@@ -44,8 +45,8 @@ locals {
 }
 
 locals {
-  aws_fn_files    = [for fn in local.aws_fn_names : "../experiments/${var.experiment}/functions/_build/${fn}.zip"]
-  google_fn_files = [for fn in local.google_fn_names : "../experiments/${var.experiment}/functions/_build/${fn}.zip"]
+  aws_fn_files    = [for fn in local.aws_fn_names : "../experiments/${local.experiment}/functions/_build/${fn}.zip"]
+  google_fn_files = [for fn in local.google_fn_names : "../experiments/${local.experiment}/functions/_build/${fn}.zip"]
 }
 
 data "google_client_config" "current" {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -42,4 +42,5 @@ fi
 echo "Running deploy for $1"
 
 cd infrastructure
-terraform apply -var "experiment=${1}"
+terraform workspace select $1
+terraform apply

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,19 +2,22 @@
 
 set -euo pipefail
 
+expname="webservice"
+
 cd infrastructure
+terraform workspace select $expname
 tfoutput=$(terraform output -json)
 cd -
 aws_url=$(echo $tfoutput | jq -r '.aws_invoke_url.value')
 google_url=$(echo $tfoutput | jq -r '.google_invoke_url.value')
 
 
-for fn in $(cat experiments/webservice/experiment.json | jq -r '.program.aws | keys[]'); do
+for fn in $(cat experiments/$expname/experiment.json | jq -r '.program.aws | keys[]'); do
   echo "Testing function: ${fn}"
-  curl -s $aws_url/${fn}/call/google | jq
+  curl -s $aws_url/${fn}
 done
 
-for fn in $(cat experiments/webservice/experiment.json | jq -r '.program.google | keys[]'); do
+for fn in $(cat experiments/$expname/experiment.json | jq -r '.program.google | keys[]'); do
   echo "Testing function: ${fn}"
-  curl -s $google_url/${fn}/call/aws | jq
+  curl -s $google_url/${fn}
 done


### PR DESCRIPTION
With the current terraform configuration it is not possible to deploy the `iot` experiment and the `webservice` in parallel. If we want to do that, we have to use [terraform workspaces](https://www.terraform.io/docs/state/workspaces.html).

What is your opinion on this?