### PR TITLE
Do not error even if azure logs are empty.

### DIFF
--- a/scripts/logs.sh
+++ b/scripts/logs.sh
@@ -42,5 +42,9 @@ az webapp log download --resource-group $project_name --name $project_name --log
 
 echo "Extracting Azure logs" | chalk magenta
 unzip $logdir/azure.zip -d $logdir/azure
-cat $logdir/azure/LogFiles/Application/Functions/Host/*.log > $logdir/azure.log
+if [[ -d $logdir/azure/LogFiles/Application/Functions/Host ]]; then
+  cat $logdir/azure/LogFiles/Application/Functions/Host/*.log > $logdir/azure.log
+else
+  echo "No azure logs found in archive." | chalk red
+fi
 rm -rf $logdir/azure.zip $logdir/azure


### PR DESCRIPTION
Azure logs directory might not exist, if no experiments have been run on azure yet. This can happen if the current config does not deploy anything to azure.