### PR TITLE
Improved webservice testing script

### DIFF
--- a/scripts/test_webservice.sh
+++ b/scripts/test_webservice.sh
@@ -10,7 +10,10 @@ cd $(git rev-parse --show-toplevel)  # go to experiments root directory
 cd infrastructure
 eval "$(terraform output | sed 's/ //g')"
 cd -
-
+if [[ -z $aws_invoke_url ]] && [[ -z $google_invoke_url ]] && [[ -z $azure_invoke_url ]]; then
+  echo -e "No cloud provider endpoints found. Probably you should first execute:\ncd infrastructure && terraform init && cd .."
+  exit 1
+fi
 
 webservice_config=./experiments/webservice/experiment.json
 


### PR DESCRIPTION
This improves the testing script merged in #60 to automatically detect function platform and the platform URL from the current terraform config.

The script now requires `jq` and that terraform has been initialized on the computer. The script will need to be executed from inside the experiments project, as it will attempt to guess the git project root.

Even though we will have artillery, this script is insofar useful, as artillery does not have internal component testing in its scope. Also it is much simpler to set-up and modify.