### PR TITLE
Add script to destroy projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "local": "node -e \"http.createServer(require(process.argv[1]).googleHandler).listen(3000)\"",
     "build": "./scripts/build.sh",
     "deploy": "./scripts/deploy.sh",
+    "destroy": "./scripts/destroy.sh",
     "logs": "./scripts/logs.sh"
   },
   "husky": {

--- a/scripts/destroy.sh
+++ b/scripts/destroy.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ -z "${1:-}" ]; then
+    chalk -t "{yellow Usage: $0 }{yellow.bold <experiment name>}"
+    echo "Choose one of:" | chalk yellow
+    chalk -t "{yellow >} {yellow.bold $(ls experiments/ | tr '\n' ' ')}"
+    echo ""
+    exit 1
+fi
+
+cd infrastructure
+terraform destroy -var "experiment=${1}" -auto-approve


### PR DESCRIPTION
Add a script for destroying projects.

Using auto-approve to allow for easier automatic deployment.